### PR TITLE
Fix unexpected token in delivery page

### DIFF
--- a/src/pages/support/DeliveryPage.tsx
+++ b/src/pages/support/DeliveryPage.tsx
@@ -90,7 +90,7 @@ export function DeliveryPage() {
                   <h3 className="font-semibold text-gray-900 mb-3">Standard Delivery</h3>
                   <ul className="space-y-2 text-sm text-gray-600">
                     <li>• Nairobi CBD: <span className="font-medium text-green-600">Free for orders ≥ KSH 5,000</span></li>
-                    <li>• Nairobi CBD: <span className="font-medium">KSH 300 for orders < KSH 5,000</span></li>
+                    <li>• Nairobi CBD: <span className="font-medium">KSH 300 for orders &lt; KSH 5,000</span></li>
                     <li>• Greater Nairobi: <span className="font-medium">KSH 500 - KSH 800</span></li>
                     <li>• Major Towns: <span className="font-medium">KSH 800 - KSH 1,500</span></li>
                     <li>• Remote Areas: <span className="font-medium">KSH 1,500 - KSH 3,000</span></li>


### PR DESCRIPTION
Replace `<` with `&lt;` in JSX to resolve a Babel parsing error.

---
<a href="https://cursor.com/background-agent?bcId=bc-fea3e3a6-1b7d-4368-b1f1-7596a95cfc37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fea3e3a6-1b7d-4368-b1f1-7596a95cfc37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

