### PR TITLE
Fix duplicate key warning for orthodontics

### DIFF
--- a/src/pages/admin/AddProductPage.tsx
+++ b/src/pages/admin/AddProductPage.tsx
@@ -64,7 +64,6 @@ export function AddProductPage() {
     'Sterilization Consumables',
     'Complete Student Kits',
     'Crown and Bridge',
-    'Orthodontics',
     'Complete Dentures',
     'Partial Dentures (Cobalt Chrome)'
   ]);


### PR DESCRIPTION
Remove duplicate "Orthodontics" category to resolve React key warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-c299b067-a293-457d-96a3-965d07c40cec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c299b067-a293-457d-96a3-965d07c40cec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

