### PR TITLE
Fix jsx attribute and mongoose isNew field

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -66,7 +66,7 @@ const productSchema = new mongoose.Schema({
   specifications: { type: Object },
   features: { type: [String], default: [] },
   brand: { type: String },
-  isNew: { type: Boolean, default: false },
+  is_new: { type: Boolean, default: false },
   isBestSeller: { type: Boolean, default: false },
   isFeatured: { type: Boolean, default: false },
   seller: { type: String },

--- a/src/components/home/FeaturedProducts.tsx
+++ b/src/components/home/FeaturedProducts.tsx
@@ -100,7 +100,7 @@ export function FeaturedProducts() {
             >
               {/* Product Badge Container */}
               <div className="absolute top-3 left-3 z-20 flex flex-col gap-1">
-                {product.isNew && (
+                {product.is_new && (
                   <span className="bg-gradient-to-r from-green-500 to-green-600 text-white text-xs px-3 py-1 rounded-full font-bold shadow-lg">
                     NEW
                   </span>

--- a/src/components/home/LightningDeals.tsx
+++ b/src/components/home/LightningDeals.tsx
@@ -17,7 +17,7 @@ const lightningDeals = [
     badge: 'Local',
     rating: 4.8,
     reviews: 89,
-    isNew: false,
+    is_new: false,
     description: 'High-quality dental handpiece set with multiple attachments for various dental procedures. Includes maintenance kit and warranty.'
   },
   {
@@ -30,7 +30,7 @@ const lightningDeals = [
     badge: 'Best Seller',
     rating: 4.9,
     reviews: 234,
-    isNew: false,
+    is_new: false,
     description: 'Advanced digital X-ray sensor kit with high resolution imaging and easy integration with existing dental systems.'
   },
   {
@@ -43,7 +43,7 @@ const lightningDeals = [
     badge: 'Hot',
     rating: 4.7,
     reviews: 567,
-    isNew: false,
+    is_new: false,
     description: 'Complete orthodontic bracket kit with various sizes and colors. Perfect for orthodontic procedures and treatments.'
   },
   {
@@ -56,7 +56,7 @@ const lightningDeals = [
     badge: 'Premium',
     rating: 4.9,
     reviews: 45,
-    isNew: true,
+    is_new: true,
     description: 'Complete dental chair unit with advanced features including hydraulic positioning, LED lighting, and integrated suction system.'
   },
   {
@@ -69,7 +69,7 @@ const lightningDeals = [
     badge: 'Essential',
     rating: 4.6,
     reviews: 312,
-    isNew: false,
+    is_new: false,
     description: 'Comprehensive infection control kit with sterilization equipment, protective gear, and cleaning solutions for dental practices.'
   }
 ];
@@ -255,7 +255,7 @@ export function LightningDeals() {
                         {deal.badge}
                       </div>
                     )}
-                    {deal.isNew && (
+                    {deal.is_new && (
                       <div className={`absolute top-2 right-2 bg-blue-500 text-white text-xs px-2 py-1 rounded-full font-medium ${
                         isMobile ? 'animate-bounce' : ''
                       }`}>

--- a/src/components/home/PartnershipBanner.tsx
+++ b/src/components/home/PartnershipBanner.tsx
@@ -66,7 +66,7 @@ export function PartnershipBanner() {
       </div>
       
       {/* Animation styles */}
-      <style jsx>{`
+      <style>{`
         @keyframes fadeInUp {
           from {
             opacity: 0;

--- a/src/components/home/ProductGrid.tsx
+++ b/src/components/home/ProductGrid.tsx
@@ -224,7 +224,7 @@ export function ProductGrid() {
               />
               
               {/* Badges */}
-              {product.isNew && (
+              {product.is_new && (
                 <div className="absolute top-2 left-2 bg-blue-500 text-white text-xs px-2 py-1 rounded-full font-medium">
                   NEW
                 </div>

--- a/src/components/home/ProductHeroSection.tsx
+++ b/src/components/home/ProductHeroSection.tsx
@@ -241,7 +241,7 @@ export function ProductHeroSection() {
               >
               {/* Product Badges */}
               <div className="absolute top-3 left-3 z-20 flex flex-col gap-1">
-                {product.isNew && (
+                {product.is_new && (
                   <span className="bg-gradient-to-r from-green-500 to-green-600 text-white text-xs px-3 py-1 rounded-full font-bold shadow-lg">
                     NEW
                   </span>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -411,7 +411,7 @@ export function AboutPage() {
       </div>
       
       {/* Animation Styles */}
-      <style jsx>{`
+      <style>{`
         @keyframes fadeInDown {
           from {
             opacity: 0;

--- a/src/pages/admin/LightningDealsManagementPage.tsx
+++ b/src/pages/admin/LightningDealsManagementPage.tsx
@@ -12,7 +12,7 @@ interface LightningDeal {
   badge: string;
   rating: number;
   reviews: number;
-  isNew: boolean;
+  is_new: boolean;
   description: string;
 }
 
@@ -30,7 +30,7 @@ export function LightningDealsManagementPage() {
     badge: '',
     rating: 0,
     reviews: 0,
-    isNew: false,
+    is_new: false,
     description: ''
   });
 
@@ -50,7 +50,7 @@ export function LightningDealsManagementPage() {
           badge: 'Local',
           rating: 4.8,
           reviews: 89,
-          isNew: false,
+          is_new: false,
           description: 'High-quality dental handpiece set with multiple attachments for various dental procedures.'
         },
         {
@@ -63,7 +63,7 @@ export function LightningDealsManagementPage() {
           badge: 'Best Seller',
           rating: 4.9,
           reviews: 234,
-          isNew: false,
+          is_new: false,
           description: 'Advanced digital X-ray sensor kit with high resolution imaging.'
         }
       ];
@@ -92,7 +92,7 @@ export function LightningDealsManagementPage() {
       badge: newDeal.badge || 'New',
       rating: newDeal.rating || 0,
       reviews: newDeal.reviews || 0,
-      isNew: newDeal.isNew || true,
+      is_new: newDeal.is_new || true,
       description: newDeal.description || ''
     };
 
@@ -107,7 +107,7 @@ export function LightningDealsManagementPage() {
       badge: '',
       rating: 0,
       reviews: 0,
-      isNew: false,
+      is_new: false,
       description: ''
     });
     alert('Lightning deal added successfully');
@@ -273,8 +273,8 @@ export function LightningDealsManagementPage() {
               <label className="flex items-center space-x-2">
                 <input
                   type="checkbox"
-                  checked={newDeal.isNew || false}
-                  onChange={(e) => setNewDeal(prev => ({ ...prev, isNew: e.target.checked }))}
+                  checked={newDeal.is_new || false}
+                  onChange={(e) => setNewDeal(prev => ({ ...prev, is_new: e.target.checked }))}
                   className="form-checkbox h-4 w-4 text-primary-600 rounded"
                 />
                 <span className="text-sm font-medium text-gray-700">Mark as New Product</span>

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -16,7 +16,7 @@ export interface Product {
   specifications?: Record<string, any>;
   features?: string[];
   brand?: string;
-  isNew?: boolean;
+  is_new?: boolean;
   isBestSeller?: boolean;
   isFeatured?: boolean;
   seller?: string;
@@ -75,7 +75,7 @@ class APIService {
         specifications: p.specifications,
         features: p.features,
         brand: p.brand,
-        isNew: p.isNew,
+        is_new: p.is_new,
         isBestSeller: p.isBestSeller,
         isFeatured: p.isFeatured,
         seller: p.seller,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,7 @@ export interface Product {
   rating?: number;
   reviews?: Review[];
   reviewCount?: number;
-  isNew?: boolean;
+  is_new?: boolean;
   isBestSeller?: boolean;
   isFeatured?: boolean;
   seller?: string;


### PR DESCRIPTION
Fixes React 'jsx' prop warning and Mongoose 'isNew' reserved field warning by correcting style tag usage and renaming the schema field to 'is_new'.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fdfdf37-b3fd-40c7-b130-affca7e5cb46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fdfdf37-b3fd-40c7-b130-affca7e5cb46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

