### PR TITLE
Secure admin pages and fix data fetching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,7 +131,7 @@ function App() {
                     <Route 
                       path="/admin/analytics" 
                       element={
-                        <ProtectedRoute>
+                        <ProtectedRoute staffRestricted={true} requiredPermission="view_analytics">
                           <AnalyticsPage />
                         </ProtectedRoute>
                       } 
@@ -139,7 +139,7 @@ function App() {
                     <Route 
                       path="/admin/settings" 
                       element={
-                        <ProtectedRoute>
+                        <ProtectedRoute staffRestricted={true} requiredPermission="manage_settings">
                           <SettingsPage />
                         </ProtectedRoute>
                       } 

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -22,7 +22,7 @@ interface AdminLayoutProps {
 
 export function AdminLayout({ children }: AdminLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { user, logout } = useAdminAuth();
+  const { user, logout, hasPermission } = useAdminAuth();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -31,16 +31,21 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     navigate('/', { replace: true });
   };
 
-  const navigation = [
+  const allNavigation = [
     { name: 'Dashboard', href: '/admin/dashboard', icon: FiHome },
     { name: 'Categories', href: '/admin/categories', icon: FiTag },
     { name: 'Products', href: '/admin/products', icon: FiPackage },
     { name: 'Lightning Deals', href: '/admin/lightning-deals', icon: FiZap },
     { name: 'Orders', href: '/admin/orders', icon: FiShoppingCart },
     { name: 'Customers', href: '/admin/customers', icon: FiUsers },
-    { name: 'Analytics', href: '/admin/analytics', icon: FiTrendingUp },
-    { name: 'Settings', href: '/admin/settings', icon: FiSettings },
+    { name: 'Analytics', href: '/admin/analytics', icon: FiTrendingUp, permission: 'view_analytics' },
+    { name: 'Settings', href: '/admin/settings', icon: FiSettings, permission: 'manage_settings' },
   ];
+
+  // Filter navigation based on user permissions
+  const navigation = allNavigation.filter(item => 
+    !item.permission || hasPermission(item.permission)
+  );
 
   const isCurrentPath = (href: string) => {
     return location.pathname === href || location.pathname.startsWith(href + '/');


### PR DESCRIPTION
Restrict staff access to Analytics and Settings pages and hide their navigation links to prevent access to sensitive information.

---
<a href="https://cursor.com/background-agent?bcId=bc-28cb2614-8333-40ec-a36b-0af8c8895e45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28cb2614-8333-40ec-a36b-0af8c8895e45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

