### PR TITLE
Fix missing keys in review management

### DIFF
--- a/src/pages/admin/ReviewManagementPage.tsx
+++ b/src/pages/admin/ReviewManagementPage.tsx
@@ -268,7 +268,7 @@ const ReviewManagementPage: React.FC = () => {
               onChange={(e) => handleFilterChange('productId', e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
-              <option value="">All Products</option>
+              <option key="" value="">All Products</option>
               {products.map(product => (
                 <option key={product.id} value={product.id}>
                   {product.name}


### PR DESCRIPTION
Add a `key` prop to the "All Products" option to resolve a React unique key warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ab011a0-3f32-46a0-9057-5eb094678cb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ab011a0-3f32-46a0-9057-5eb094678cb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

