### PR TITLE
Fix homepage cutoff and page spacing issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,7 +182,7 @@ function App() {
                       element={
                         <>
                           <Header />
-                          <main className="flex-1 pt-20">
+                          <main className="flex-1 pt-16">
                             <ProductsPage />
                           </main>
                           <Footer />
@@ -195,7 +195,7 @@ function App() {
                       element={
                         <>
                           <Header />
-                          <main className="flex-1 pt-20">
+                          <main className="flex-1 pt-16">
                             <ProductsPage />
                           </main>
                           <Footer />
@@ -247,7 +247,7 @@ function App() {
                       element={
                         <>
                           <Header />
-                          <main className="flex-1 pt-20">
+                          <main className="flex-1 pt-16">
                             <ContactPage />
                           </main>
                           <Footer />
@@ -260,7 +260,7 @@ function App() {
                       element={
                         <>
                           <Header />
-                          <main className="flex-1 pt-20">
+                          <main className="flex-1 pt-16">
                             <AboutPage />
                           </main>
                           <Footer />

--- a/src/components/common/ScrollOverlaySection.tsx
+++ b/src/components/common/ScrollOverlaySection.tsx
@@ -16,7 +16,7 @@ export const ScrollOverlaySection: React.FC<ScrollOverlaySectionProps> = ({
   className = '',
   bgColor = 'bg-white',
   zIndex = 1,
-  minHeight = 'min-h-screen',
+  minHeight = 'min-h-[100dvh]',
   id,
   enableParallax = false,
   offsetY = 0

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,37 @@
 
   /* Enhanced mobile-specific improvements */
   @media (max-width: 767px) {
+    /* Fix viewport height issues on mobile desktop mode */
+    .min-h-screen,
+    .min-h-\[100vh\],
+    .min-h-\[100dvh\] {
+      min-height: 100vh !important;
+      min-height: 100dvh !important;
+    }
+
+    /* Ensure content doesn't get cut off on mobile desktop mode */
+    .scroll-overlay-container {
+      overflow-x: hidden !important;
+      overflow-y: auto !important;
+      position: relative !important;
+    }
+
+    .scroll-overlay-section {
+      overflow: visible !important;
+      min-height: auto !important;
+      position: relative !important;
+    }
+
+    /* Ensure all sections are visible on mobile desktop mode */
+    #hero-section,
+    #deals-section,
+    #products-section,
+    #features-section {
+      position: relative !important;
+      z-index: auto !important;
+      min-height: auto !important;
+    }
+
     /* Ensure touch targets are at least 44px */
     button, .btn, a[role="button"] {
       min-height: 48px;
@@ -152,6 +183,32 @@
 
     .admin-table-actions {
       min-width: 120px;
+    }
+  }
+
+  /* Mobile devices in desktop mode - typical tablet/mobile with desktop viewport */
+  @media (min-width: 768px) and (max-width: 1024px) and (pointer: coarse) {
+    /* Fix viewport issues for mobile devices simulating desktop */
+    .scroll-overlay-container {
+      overflow-x: hidden !important;
+      overflow-y: auto !important;
+    }
+
+    .scroll-overlay-section {
+      position: relative !important;
+      min-height: auto !important;
+      overflow: visible !important;
+    }
+
+    /* Ensure all homepage sections display */
+    #hero-section,
+    #deals-section,
+    #products-section,
+    #features-section {
+      position: relative !important;
+      z-index: auto !important;
+      min-height: auto !important;
+      display: block !important;
     }
   }
 

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -36,7 +36,7 @@ export function AboutPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-white via-orange-50/30 to-white pt-20 scroll-container">
+    <div className="min-h-screen bg-gradient-to-b from-white via-orange-50/30 to-white pt-8 scroll-container">
       {/* SEO Meta Information */}
       <div style={{ display: 'none' }}>
         <h1>Rurident Health Supplies - More Than Tools. A Legacy in Every Smile.</h1>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -5,7 +5,7 @@ export function ContactPage() {
   const [activeTab, setActiveTab] = useState('location');
 
   return (
-    <div className="min-h-screen bg-gray-50 pt-20">
+    <div className="min-h-screen bg-gray-50 pt-8">
       {/* Hero Section */}
       <div className="bg-gradient-to-r from-orange-500 to-red-500 text-white">
         <div className="container-max py-12 md:py-16">

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -79,7 +79,7 @@ export function ProductsPage() {
   // Show loading state
   if (loading) {
     return (
-      <main className="min-h-screen bg-gray-50 py-8 pt-32">
+      <main className="min-h-screen bg-gray-50 py-8 pt-8">
         <div className="container-max">
           <div className="flex justify-center items-center h-64">
             <div className="text-center">
@@ -207,7 +207,7 @@ export function ProductsPage() {
   }, [filteredProducts, sortBy]);
 
   return (
-    <div className="min-h-screen bg-gray-50 pt-32 products-page-container">
+    <div className="min-h-screen bg-gray-50 pt-8 products-page-container">
       {/* Wave Gradient Background */}
       <div className="wave-gradient-bg"></div>
       


### PR DESCRIPTION
Adjust CSS to fix homepage content cutoff on mobile desktop mode and reduce excessive top spacing on other pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c13dfd3-25a2-4953-b536-e7e52715de55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c13dfd3-25a2-4953-b536-e7e52715de55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

