### PR TITLE
Fix website display and api errors

### DIFF
--- a/src/context/AdminAuthContext.tsx
+++ b/src/context/AdminAuthContext.tsx
@@ -27,6 +27,9 @@ const AdminAuthContext = createContext<AdminAuthContextType | undefined>(undefin
 export function AdminAuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AdminUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const apiBase = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE_URL)
+    ? `${import.meta.env.VITE_API_BASE_URL.replace(/\/$/, '')}`
+    : '';
 
   useEffect(() => {
     // Check if user is already logged in
@@ -54,7 +57,7 @@ export function AdminAuthProvider({ children }: { children: ReactNode }) {
 
     try {
       // Authenticate with server
-      const response = await fetch('/api/admin/login', {
+      const response = await fetch(`${apiBase}/api/admin/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -128,7 +131,7 @@ export function AdminAuthProvider({ children }: { children: ReactNode }) {
     if (!user) return false;
 
     try {
-      const response = await fetch('/api/admin/credentials', {
+      const response = await fetch(`${apiBase}/api/admin/credentials`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/src/services/categoryService.ts
+++ b/src/services/categoryService.ts
@@ -16,7 +16,9 @@ export interface Category {
 }
 
 class CategoryService {
-  private baseURL = '/api';
+  private baseURL = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE_URL)
+    ? `${import.meta.env.VITE_API_BASE_URL.replace(/\/$/, '')}/api`
+    : '/api';
 
   async getCategories(): Promise<{ success: boolean; data?: Category[]; error?: string }> {
     try {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -26,7 +26,9 @@ export interface Product {
 }
 
 class APIService {
-  private baseURL = '/api';
+  private baseURL = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE_URL)
+    ? `${import.meta.env.VITE_API_BASE_URL.replace(/\/$/, '')}/api`
+    : '/api';
   // When true, the service will not attempt to use mock data; it will surface real errors instead
   private alwaysUseLiveApi = true;
 


### PR DESCRIPTION
Configure frontend and admin API calls to use an environment-based base URL to resolve 404 errors and enable proper functionality on Render deployment.

Previously, the frontend was making relative API calls (`/api/...`), which resulted in 404 errors when deployed to Render as a separate service from the backend. This change allows the frontend to correctly target the backend service via the `VITE_API_BASE_URL` environment variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cdd6775-e492-4ea4-8088-8e6aebb81f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cdd6775-e492-4ea4-8088-8e6aebb81f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

